### PR TITLE
Tighten README first-screen formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ PATAS Core is a pattern-discovery and rule-management system for anti-spam teams
 
 **[Open the live demo](https://patas.app/demo)**
 
-[Run locally](#quickstart) · [Examples](examples/) · [Architecture map](app/README.md)
+[Docs](#documentation) · [Examples](examples/) · [Architecture map](app/README.md)
+
+Sample output:
+
+```text
+Pattern group -> reviewable rule candidate -> evaluation metrics
+```
 
 PATAS analyzes message logs, groups similar spam patterns, generates reviewable blocking rules, and tracks rule evaluation metrics. It is evaluation software for technical review, not a hosted moderation guarantee.
 


### PR DESCRIPTION
## Summary
- Tighten the README first screen around the KikuAI presentation formula.
- Add or clarify sample output / expected output, primary CTA, and compact secondary navigation.
- Keep claims grounded in the existing repository behavior and status.

## Verification
- git diff --check
- local README formula audit: 5/5 for this repository

## Secrets check
- no real secrets added; README-only presentation change.